### PR TITLE
Stormchaser's Gambit -1250 OnEnd glitch fixed

### DIFF
--- a/cardlibrary/ancientstirrings.lua
+++ b/cardlibrary/ancientstirrings.lua
@@ -433,13 +433,12 @@ local stirrings = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 		["AttackEffect"] = "Dash",
 		["Color"] = "Blue", 
 		["Cost"] = {["Blue"] = 99,},
-		["Archetype"] = "Gambit",
 		["AttackBlock"] = true,
 		["Effect"] = {
 			Name = "Pyrotechnics",
 			Description = "7 Charges. At the end of this turn, if you've cast 7 action or terrain spells after this one, deal 1250 damage to the opponent.",
 			["Type"] = "OnEnd",
-			["Power"] = {{"Inflict",1250}},
+			["Power"] = {{"Inflict",1250}},{{"Damage",9999,"Self"}}
 			Target = "Opponent",
 		},
 		["Bio"] = "Grapeshots ruined, Tendrils of Agony depleted. All that is left is the rush.",		


### PR DESCRIPTION
Stormchaser's Gambit has a loophole in it, which can be caused by swap-stating the reminder. When you kill this reminder, there's nothing to kill the Stormchaser's Gambit tokens, including the one that deals 1250 damage OnEnd. If you buff that token's health, you can kill your opponent with -1250 life every turn and with ease.

Changing the power to make the token deal 9999 damage to itself at the end of its turn will fix this.

["Power"] = {{"Inflict",1250}},{{"Damage",9999,"Self"}}

I also un-archetyped it to prevent potential crashes with the reminder for Stormchaser's Gambit. 