### PR TITLE
Attempting to fix RoboticMob's glitch

### DIFF
--- a/cardlibrary/baselibrary.lua
+++ b/cardlibrary/baselibrary.lua
@@ -4015,7 +4015,7 @@ local base = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			Name = "Overhaul",
 			Description = "Deal 300 damage to a target fighter and the opponent.",
 			["Type"] = "OnSummon",
-			["Power"] = {{"Damage",300},{"Inflict",300,"Opponent"}},
+			["Power"] = {{"Inflict",300,"Opponent"},{"Damage",300}},
 			Target = "Single",
 		},
 		["Bio"] = "Fills in at local saleless stores on Black Friday.",


### PR DESCRIPTION
Apparently, when you use RoboticMob and use the target damage on itself, it breaks the game. This is because of there being no entity to deal the damage to the opponent, even though it says it in the code.

Attempting to patch this glitch by having the opponent damage go first in the code, although I'm not certain that it'll work. It's worth a try, at least.