### PR TITLE
Fix "Ghosting" fighters

### DIFF
--- a/cardlibrary/10.12.16.lua
+++ b/cardlibrary/10.12.16.lua
@@ -2579,7 +2579,7 @@ local tentwelvesixteen = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			Name = "Life fam",
 			Description = "Summon two Zombies. Whenever an allied fighter dies, Zabiehunter drains 200 health from your opponent.",
 			["Type"] = "OnSummon",
-			["Power"] = {{"Summon","Zabiehuntertoken"},{"Damage",9999,"Self"},{"Summon","Zombie"},{"Summon","Zombie"}},
+			["Power"] = {{"Summon","Zabiehuntertoken"},{"Summon","Zombie"},{"Summon","Zombie"},{"Damage",9999,"Self"}},
 			Target = "Ally",
 		},
 		["Bio"] = [[I want to see if the light can pass through me.]],

--- a/cardlibrary/ancientstirrings.lua
+++ b/cardlibrary/ancientstirrings.lua
@@ -2130,7 +2130,7 @@ local stirrings = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			Name = "Haydoscale",
 			Description = "When played, summon a copy of this card. When this card attacks and destroys another, draw a card.",
 			["Type"] = "OnSummon",
-			["Power"] = {{"Summon","Lead"},{"Damage",9999,"Self"},{"Summon","Lead"}},
+			["Power"] = {{"Summon","Lead"},{"Summon","Lead"},{"Damage",9999,"Self"}},
 			Target = "Ally",
 		},
 		["Bio"] = "From fan to murderer.",


### PR DESCRIPTION
"ghosting" refers to when a fighter is summoned offscreen, preventing players from interacting with it naturally. (AoE can still affect "ghosting" fighters)