### PR TITLE
Added Bearded Captain to the Blue Thought pack

### DIFF
--- a/packs.lua
+++ b/packs.lua
@@ -601,6 +601,7 @@ local packs = {
 			"hyp3rdeath",
 			"Steam Razikai",
 			"Jimminus",
+			"Bearded Captain",
 			"Wooden Chair",
  			"Rollernaut",
 			"SONICTHEHEDGEHOGXXX",


### PR DESCRIPTION
Apparently, Bearded Captain isn't in the Blue Thought Pack. Only in the Green Vitality packs.