### PR TITLE
Stickmasterluke Rework

### DIFF
--- a/cardlibrary/baselibrary.lua
+++ b/cardlibrary/baselibrary.lua
@@ -3548,9 +3548,9 @@ local base = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 		["Cost"] = {["Green"] = 5,["Neutral"] = 1,},
 		["Effect"] = {
 			Name = "Disaster",
-			Description = "You gain 500 life. Put 2 targeting blips into your hand. Targeting blips are used to trigger Target Effects.",
-			["Type"] = "OnSummon",
-			["Power"] = {{"Cost",-500},{"Add","Targeting Blip","Ally"},{"Add","Targeting Blip","Ally"}},
+			Description = "Whenever Stickmasterluke attacks, he drains 150 Health from a target fighter.",
+			["Type"] = "OnAttack",
+			["Power"] = {{"Heal",150,"Self"},{"Damage",150}},
 			Target = "Opponent",
 		},
 		["Bio"] = "Most likely accident prone worker at ROBLOX. He made it there from scripting, so can you!",

--- a/cardlibrary/baselibrary.lua
+++ b/cardlibrary/baselibrary.lua
@@ -3551,7 +3551,7 @@ local base = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			Description = "Whenever Stickmasterluke attacks, he drains 150 Health from a target fighter.",
 			["Type"] = "OnAttack",
 			["Power"] = {{"Heal",150,"Self"},{"Damage",150}},
-			Target = "Opponent",
+			Target = "Single",
 		},
 		["Bio"] = "Most likely accident prone worker at ROBLOX. He made it there from scripting, so can you!",
 	},


### PR DESCRIPTION
Whenever Stickmasterluke attacks, he drains 150 Health from a target fighter.