### PR TITLE
DunclubDuncan

### DIFF
--- a/cardlibrary/10.12.16.lua
+++ b/cardlibrary/10.12.16.lua
@@ -4542,7 +4542,7 @@ local tentwelvesixteen = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			["Power"] = {{"Lock",2},{"Summon","DunclubDuncan Token","Ally"},{"Damage",9999,"Self"}},
 			Target = "All",
 		},
-		["Bio"] = "",
+		["Bio"] = "me me big boy",
 	},
 	
 	["DunclubDuncan Token"] = {
@@ -4561,7 +4561,7 @@ local tentwelvesixteen = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 			["Power"] = {{"Lock",1}},
 			Target = "Single",
 		},
-		["Bio"] = "",
+		["Bio"] = "me me smol boy",
 	},
 	
 }

--- a/cardlibrary/10.12.16.lua
+++ b/cardlibrary/10.12.16.lua
@@ -4526,5 +4526,43 @@ local tentwelvesixteen = { -- CARD_ID, NAME, POWER, HEALTH, RARITY,BIO
 		["Bio"] = [[WESKER202 THE NINJAFOX PLOWS VISLEAF THE BLOBUNNY AND FERTILIZES THEIR EGGS IN THE NEW HIT MOVIE "ZOOTOPIA 2: VIABLE LIFEGAIN BOOGALOO"!!!]],
 	},
 	
+	["DunclubDuncan"] = {
+		["Id"] = 1512697995,
+		["Name"] = "DunclubDuncan",
+		["Health"] = 1250,
+		["Power"] = 500,
+		["Rarity"] = "Legendary",
+		["AttackEffect"] = "Dash",
+		["Color"] = "Blue", 
+		["Cost"] = {["Neutral"] = 5, ["Blue"] = 6,},
+		["Effect"] = {
+			Name = "Clash",
+			Description = "When this card dies, lock all fighters for two turns, then transform DunclubDuncan into its flank mode.",
+			["Type"] = "OnDeath",
+			["Power"] = {{"Lock",2},{"Summon","DunclubDuncan Token","Ally"},{"Damage",9999,"Self"}},
+			Target = "All",
+		},
+		["Bio"] = "",
+	},
+	
+	["DunclubDuncan Token"] = {
+		["Id"] = 1512698272,
+		["Name"] = "DunclubDuncan",
+		["Health"] = 500,
+		["Power"] = 500,
+		["Rarity"] = "Token",
+		["AttackEffect"] = "Dash",
+		["Color"] = "Blue", 
+		["Cost"] = {["Neutral"] = 5, ["Blue"] = 6,},
+		["Effect"] = {
+			Name = "Clash",
+			Description = "Whenever this card attacks, lock a target fighter for one turn.",
+			["Type"] = "OnAttack",
+			["Power"] = {{"Lock",1}},
+			Target = "Single",
+		},
+		["Bio"] = "",
+	},
+	
 }
 return tentwelvesixteen

--- a/packs.lua
+++ b/packs.lua
@@ -197,6 +197,7 @@ local packs = {
 			"Histor, Blood Warrior",
 			"Aesura",
 			"superkicker2005",
+			"AMerryCan",
 			"Shard Master",
 			"Beyondthegong",
 			"Damaging26",
@@ -593,12 +594,14 @@ local packs = {
 		CardPackId = 721399466,
 		Description = "Blue is the colour of logic, order, and structure. Thought packs contain cards that cost blue!",
 		Cards = {
+			"DunclubDuncan",
 			"Creeperkiller510",
 			"Modern Chair",
 			"Permafrost Storm",
 			"MesouricPhantom976",
 			"Silver_Semtexagon",
 			"Arte71",
+			"AMerryCan",
 			"kickertoken",
 			"ImaUMBREON",
 			"caone",
@@ -1027,6 +1030,7 @@ local packs = {
 		Description = "Exotic new cards from the black market! White cards and joke cards! It's all yours, as long as you have 10 wins!",
 		WinRequirement = 10;
 		Cards = {
+			"DunclubDuncan",
 			"Damarioguy",
 			"Creeperkiller510",
 			"Tl_rd",
@@ -1105,7 +1109,6 @@ local packs = {
 			"BandiheartYT",
 			"BrandonOccult",
 			"Fenfie08",
-			"AMerryCan",
 			-- PAST THIS POINT IS FOR WHITE CARDS AND JOKE CARDS ONLY. I'M LOOKING AT YOU, BLITZ.
 			"SpeedySeat",
 			"Dukran the Celestial",
@@ -1345,6 +1348,7 @@ local packs = {
 		Description = "Filled with only cards belonging to an archetype, this pack can help you finish your deck provided you have at least 10 wins.",
 		WinRequirement = 10;
 		Cards = {
+			"AMerryCan",
 			"Creeperkiller510",
 			"Alar Myrmidon",
 			"Alar Sentinel",


### PR DESCRIPTION
5W6B 1250/500 OnDeath lock all fighters for two turns, then transform this card into its flank mode
Flank Mode: 500/500 OnAttack lock a target fighter for a turn

Note that AMerryCan doesn't appear in packs outside of Exotic, apparently.